### PR TITLE
[0.3.0] compile and run spec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>pfeodrippe</groupId>
   <artifactId>tla-edn</artifactId>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <name>tla-edn</name>
   <description></description>
   <url>https://github.com/pfeodrippe/tla-edn</url>


### PR DESCRIPTION
- When running spec, compile the operators if not already compiled.
- The number of arguments is passed to the hash function.
- ` classes-to-be-loaded` is now a map from operator class (as a symbol) to namespace where the operator is defined.